### PR TITLE
Polish

### DIFF
--- a/spring-boot-starter-rollbar/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-boot-starter-rollbar/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -4,21 +4,6 @@
       "name": "com.rollbar.enabled",
       "type": "java.lang.Boolean",
       "description": "Set this to false to disable the Rollbar Notification Service."
-    },
-    {
-      "name": "com.rollbar.access-token",
-      "type": "java.lang.String",
-      "description": "The access token to use."
-    },
-    {
-      "name": "com.rollbar.environment",
-      "type": "java.lang.String",
-      "description": "Represents the current environment (e.g.: production, debug, test)."
-    },
-    {
-      "name": "com.rollbar.code-version",
-      "type": "java.lang.String",
-      "description": "The currently running version of the code. If unset, the commit.id is taken from the git.properties if found."
     }
   ]
 }


### PR DESCRIPTION
No need to duplicate keys in manual metadata as the annotation processor
takes care of that already.