### PR TITLE
use junit5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,10 @@
 		<java.version>1.8</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<lombok.version>1.16.20</lombok.version>
+		<junit.jupiter.version>5.3.1</junit.jupiter.version>
+		<junit.platform.version>1.3.1</junit.platform.version>
+		<maven-surefire-plugin-version>2.22.0</maven-surefire-plugin-version>
+		<mockito-junit-jupiter-version>2.22.0</mockito-junit-jupiter-version>
 	</properties>
 
 	<scm>
@@ -84,6 +88,12 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
 			<scope>test</scope>
 		</dependency>
 
@@ -92,15 +102,39 @@
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>${junit.jupiter.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-engine</artifactId>
+			<version>${junit.jupiter.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<version>${mockito-junit-jupiter-version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
 		<plugins>
-            <!-- Surefire plugin fails with newer versions of the plugin on Docker and Alpine http://raehal.me/maven-surefire-plugin-on-Docker/ -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20</version>
+                <version>${maven-surefire-plugin-version}</version>
+				<dependencies>
+					<dependency>
+						<groupId>org.junit.jupiter</groupId>
+						<artifactId>junit-jupiter-engine</artifactId>
+						<version>${junit.jupiter.version}</version>
+					</dependency>
+				</dependencies>
             </plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/rollbar-logback-spring-boot-starter/src/test/java/ch/olmero/rollbar/logback/LogbackLoggingConfigurerTest.java
+++ b/rollbar-logback-spring-boot-starter/src/test/java/ch/olmero/rollbar/logback/LogbackLoggingConfigurerTest.java
@@ -5,20 +5,20 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 import org.springframework.mock.env.MockEnvironment;
 
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
-public class LogbackLoggingConfigurerTest {
+@ExtendWith(MockitoExtension.class)
+class LogbackLoggingConfigurerTest {
 
 	private LogbackLoggingConfigurer logbackLoggingConfigurer;
 	@Mock
@@ -27,19 +27,19 @@ public class LogbackLoggingConfigurerTest {
 
 	private Logger rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
 
-	@Before
-	public void setup() {
+	@BeforeEach
+	void setup() {
 		this.environment = new MockEnvironment();
 		logbackLoggingConfigurer = new LogbackLoggingConfigurer(this.environment);
 	}
 
-	@After
-	public void rest() {
-		((Logger)LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).detachAppender(LogbackRollbarAppender.NAME);
+	@AfterEach
+	void rest() {
+		((Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME)).detachAppender(LogbackRollbarAppender.NAME);
 	}
 
 	@Test
-	public void rootLevelDefault() {
+	void rootLevelDefault() {
 		logbackLoggingConfigurer.configure(rollbarNotificationService);
 		rollbarAppender().doAppend(loggingEvent(Level.ERROR, "message"));
 		verify(this.rollbarNotificationService).log("message", null, RollbarNotificationService.Level.ERROR);
@@ -49,7 +49,7 @@ public class LogbackLoggingConfigurerTest {
 	}
 
 	@Test
-	public void overrideRootLevel() {
+	void overrideRootLevel() {
 		this.environment.setProperty("com.rollbar.logging.level.root", "INFO");
 		logbackLoggingConfigurer.configure(rollbarNotificationService);
 
@@ -64,7 +64,7 @@ public class LogbackLoggingConfigurerTest {
 	}
 
 	@Test
-	public void additionalLevelDefinitionIsEvaluatedHigherThanRoot() {
+	void additionalLevelDefinitionIsEvaluatedHigherThanRoot() {
 		this.environment
 			.withProperty("com.rollbar.logging.level.root", "WARN")
 			.withProperty("com.rollbar.logging.level.ch.olmero.rollbar.logback", "DEBUG");
@@ -76,7 +76,7 @@ public class LogbackLoggingConfigurerTest {
 	}
 
 	@Test
-	public void additionalLevelDefinitionIsOFF() {
+	void additionalLevelDefinitionIsOFF() {
 		this.environment
 			.withProperty("com.rollbar.logging.level.root", "WARN")
 			.withProperty("com.rollbar.logging.level.ch.olmero.rollbar.logback", "OFF");
@@ -88,11 +88,11 @@ public class LogbackLoggingConfigurerTest {
 	}
 
 	private LogbackRollbarAppender rollbarAppender() {
-		return (LogbackRollbarAppender)this.rootLogger.getAppender(LogbackRollbarAppender.NAME);
+		return (LogbackRollbarAppender) this.rootLogger.getAppender(LogbackRollbarAppender.NAME);
 	}
 
 	private ILoggingEvent loggingEvent(Level level, String message) {
-		Logger logger = (Logger)LoggerFactory.getLogger(getClass());
+		Logger logger = (Logger) LoggerFactory.getLogger(getClass());
 		return new LoggingEvent("", logger, level, message, null, null);
 	}
 

--- a/rollbar-logback-spring-boot-starter/src/test/java/ch/olmero/rollbar/logback/LogbackRollbarAppenderIntegrationTest.java
+++ b/rollbar-logback-spring-boot-starter/src/test/java/ch/olmero/rollbar/logback/LogbackRollbarAppenderIntegrationTest.java
@@ -3,8 +3,8 @@ package ch.olmero.rollbar.logback;
 import ch.olmero.rollbar.RollbarNotificationService;
 import ch.olmero.rollbar.configuration.RollbarAutoConfiguration;
 import lombok.extern.slf4j.Slf4j;
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
@@ -14,16 +14,16 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 @Slf4j
-public class LogbackRollbarAppenderIntegrationTest {
+class LogbackRollbarAppenderIntegrationTest {
 	private AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
-	@After
-	public void after() {
+	@AfterEach
+	void after() {
 		this.context.close();
 	}
 
 	@Test
-	public void overrideRootLevel() {
+	void overrideRootLevel() {
 		TestPropertyValues.of("com.rollbar.logging.level.root=INFO",
 				"com.rollbar.access-token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
 				"com.rollbar.environment=test").applyTo(this.context);

--- a/rollbar-logback-spring-boot-starter/src/test/java/ch/olmero/rollbar/logback/LogbackRollbarAppenderTest.java
+++ b/rollbar-logback-spring-boot-starter/src/test/java/ch/olmero/rollbar/logback/LogbackRollbarAppenderTest.java
@@ -5,25 +5,25 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggingEvent;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 
-@RunWith(MockitoJUnitRunner.class)
-public class LogbackRollbarAppenderTest {
+@ExtendWith(MockitoExtension.class)
+class LogbackRollbarAppenderTest {
 	@Mock
 	private RollbarNotificationService rollbarNotificationService;
 	@InjectMocks
 	private LogbackRollbarAppender rollbarAppender;
 
 	@Test
-	public void levelMapping() {
+	void levelMapping() {
 		this.rollbarAppender.append(loggingEvent(Level.ALL, "all"));
 		verify(this.rollbarNotificationService).log("all", null, null);
 
@@ -46,7 +46,7 @@ public class LogbackRollbarAppenderTest {
 	}
 
 	@Test
-	public void appendWithThrowable() {
+	void appendWithThrowable() {
 		Exception exception = new Exception("exception");
 		this.rollbarAppender.append(loggingEvent(Level.ALL, "all", exception));
 		verify(this.rollbarNotificationService).log("all", exception, null);

--- a/rollbar-spring-boot-starter/src/test/java/ch/olmero/rollbar/configuration/RollbarAutoConfigurationTest.java
+++ b/rollbar-spring-boot-starter/src/test/java/ch/olmero/rollbar/configuration/RollbarAutoConfigurationTest.java
@@ -6,21 +6,21 @@ import com.rollbar.notifier.Rollbar;
 import com.rollbar.notifier.config.Config;
 import com.rollbar.notifier.config.ConfigBuilder;
 import com.rollbar.notifier.config.ConfigProvider;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class RollbarAutoConfigurationTest {
+class RollbarAutoConfigurationTest {
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withConfiguration(AutoConfigurations.of(RollbarAutoConfiguration.class))
 		.withPropertyValues("com.rollbar.accessToken=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
 			"com.rollbar.environment=test");
 
 	@Test
-	public void verifyConfiguration() {
+	void verifyConfiguration() {
 		this.contextRunner
 			.run(context -> {
 				Rollbar rollbar = context.getBean(Rollbar.class);
@@ -34,7 +34,7 @@ public class RollbarAutoConfigurationTest {
 	}
 
 	@Test
-	public void verifyNotificationService() {
+	void verifyNotificationService() {
 		this.contextRunner
 			.run(context -> assertThat(context).hasSingleBean(DefaultRollbarNotificationService.class));
 	}
@@ -49,14 +49,14 @@ public class RollbarAutoConfigurationTest {
 	}
 
 	@Test
-	public void disableRollbar() {
+	void disableRollbar() {
 		this.contextRunner
 			.withPropertyValues("com.rollbar.enabled:false")
 			.run(context -> assertThat(context).hasSingleBean(NoOpRollbarNotificationService.class));
 	}
 
 	@Test
-	public void useCodeVersion() {
+	void useCodeVersion() {
 		this.contextRunner
 			.withPropertyValues("com.rollbar.codeVersion=23218add")
 			.run(context -> {
@@ -66,7 +66,7 @@ public class RollbarAutoConfigurationTest {
 	}
 
 	@Test
-	public void useCommitIdFromProjectInfoAsCodeVersion() {
+	void useCommitIdFromProjectInfoAsCodeVersion() {
 		this.contextRunner
 			.withConfiguration(AutoConfigurations.of(ProjectInfoAutoConfiguration.class))
 			.run(context -> {

--- a/rollbar-spring-boot-starter/src/test/java/ch/olmero/rollbar/configuration/RollbarPropertiesTest.java
+++ b/rollbar-spring-boot-starter/src/test/java/ch/olmero/rollbar/configuration/RollbarPropertiesTest.java
@@ -3,7 +3,7 @@ package ch.olmero.rollbar.configuration;
 import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
 import org.assertj.core.util.Throwables;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.properties.bind.validation.BindValidationException;
 import org.springframework.boot.test.util.TestPropertyValues;
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class RollbarPropertiesTest {
 	@Test
-	public void missingRequiredProperties() {
+	void missingRequiredProperties() {
 		try (AnnotationConfigApplicationContext context = createContext()) {
 			Assertions.fail("Expected BindException to be thrown");
 		} catch (Exception e) {
@@ -39,7 +39,7 @@ public class RollbarPropertiesTest {
 	}
 
 	@Test
-	public void shouldBeValid() {
+	void shouldBeValid() {
 		try (AnnotationConfigApplicationContext context = createContext("com.rollbar.accessToken:abc", "com.rollbar.environment:test")) {
 		}
 	}


### PR DESCRIPTION
This PR introduces junit5 and gets rid of junit4.
The problem with surefire, docker and alpine is also fixed in the 2.22.0 version